### PR TITLE
Fix preloaded listener type

### DIFF
--- a/templates/base/src/global.d.ts
+++ b/templates/base/src/global.d.ts
@@ -1,7 +1,7 @@
 
 interface PreloadAPI {
   getDarkMode?: () => Promise<boolean>;
-  on: (channel: string, listener: (...args: unknown[]) => void) => void;
+  on: (channel: string, listener: (...args: any[]) => void) => void;
   send: (channel: string, data?: unknown) => void;
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary
- type `PreloadAPI.on` listener args as `any[]`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686454c2c364832f98135e043ee9e49b