### PR TITLE
Fix Electron dev ES module error

### DIFF
--- a/src/config/scripts.js
+++ b/src/config/scripts.js
@@ -1,7 +1,9 @@
 // File: src/config/scripts.js
 
 export const scriptOptions = [
-  { title: "npm run dev → Start dev mode (Vite + Electron)", value: "dev", selected: true, description: "Hot reload" },
+  { title: "npm run dev → Run Vite dev server", value: "dev", selected: true, description: "Renderer dev" },
+  { title: "npm run electron → Launch Electron", value: "electron" },
+  { title: "npm run start → Dev server + Electron", value: "start", selected: true, description: "Full dev" },
   { title: "npm run build → Compile TypeScript + bundle", value: "build", selected: true, description: "Production bundle" },
   { title: "npm run dist → Create standalone app (electron-builder)", value: "dist", selected: true, description: "Package installer" },
   { title: "npm run clean → Remove build/dist/cache folders", value: "clean", description: "Clear output" },
@@ -10,12 +12,14 @@ export const scriptOptions = [
   { title: "npm test → Run Node.js tests", value: "test", selected: true, description: "node --test" },
   { title: "npm run reset → Clean + reinstall deps", value: "reset", description: "Full reinstall" },
   { title: "npm run dbinit → Initialize SQLite schema", value: "dbinit", description: "Setup DB" },
-  { title: "npm run start → Launch production build", value: "start", description: "Run compiled app" }
+  { title: "npm run start → Launch production build", value: "start-build", description: "Run compiled app" }
 ];
 
 export const fullScriptMap = {
-  dev: "cross-env NODE_ENV=development concurrently \"tsc -w\" \"vite --config vite.config.js\" \"electron .\"",
-  build: "vite build && tsc",
+  dev: "vite --config vite.config.ts",
+  electron: "electron .",
+  start: "concurrently -k \"vite\" \"wait-on http://localhost:3000 && electron .\"",
+  build: "tsc && vite build",
   dist: "electron-builder",
   clean: "rimraf dist build .cache",
   lint: "eslint . --ext .ts,.tsx",
@@ -23,5 +27,5 @@ export const fullScriptMap = {
   test: "node --test",
   reset: "rimraf node_modules && npm install",
   dbinit: "node scripts/init-db.js",
-  start: "node dist/main.js"
+  "start-build": "node dist/main.js"
 };

--- a/src/generator.js
+++ b/src/generator.js
@@ -47,14 +47,16 @@ export async function scaffoldProject(answers, options = {}) {
 
   // Define required dependencies explicitly
   const dependencies = {
-    vite: "^4.0.0",
-    "@vitejs/plugin-react": "^3.0.0",
     react: "^18.0.0",
     "react-dom": "^18.0.0",
-    electron: "^25.0.0"
+    electron: "^29.0.0"
   };
 
   const devDependencies = {
+    vite: "^4.5.14",
+    "@vitejs/plugin-react": "^3.0.0",
+    typescript: "^5.4.5",
+    "@types/node": "^20.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0"
   };
@@ -80,7 +82,7 @@ export async function scaffoldProject(answers, options = {}) {
     author: answers.author,
     license: answers.license,
     type: "module",
-    main: "dist/main.js",
+    main: "electron-main.mjs",
     scripts: {},
     dependencies: {},
     devDependencies: {},
@@ -112,12 +114,12 @@ export async function scaffoldProject(answers, options = {}) {
   if (answers.scripts.includes("clean") || answers.scripts.includes("reset")) {
     pkg.devDependencies["rimraf"] = "^6.0.1";
   }
-  if (answers.scripts.includes("dev")) {
-    pkg.devDependencies["cross-env"] = "^7.0.3";
-    pkg.devDependencies["concurrently"] = "^8.2.0";
+  if (answers.scripts.includes("start")) {
+    pkg.devDependencies.concurrently = "^8.2.2";
+    pkg.devDependencies["wait-on"] = "^7.0.1";
   }
   if (answers.scripts.includes("dev") || answers.scripts.includes("build")) {
-    pkg.devDependencies["typescript"] = "^5.4.0";
+    pkg.devDependencies.typescript = "^5.4.5";
     pkg.devDependencies["@types/node"] = "^20.0.0";
   }
 

--- a/templates/base/electron-main.mjs
+++ b/templates/base/electron-main.mjs
@@ -1,0 +1,4 @@
+import('./dist/main.js').catch((err) => {
+  console.error('Failed to launch Electron main process:', err);
+  process.exit(1);
+});

--- a/templates/base/tsconfig.json
+++ b/templates/base/tsconfig.json
@@ -1,20 +1,21 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "node",
-    "allowJs": true,
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
-    "outDir": "dist",
-    "baseUrl": ".",
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
     "jsx": "react-jsx",
-    "types": ["node", "vite/client"]
+    "types": ["vite/client", "node"]
   },
   "include": [
     "src",
     "src/**/*.ts",
-    "src/**/*.js",
-    "src/global.d.ts"
-  ]
+    "src/**/*.d.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
 }

--- a/test/build-script.test.js
+++ b/test/build-script.test.js
@@ -14,7 +14,7 @@ function createNpmStub() {
 }
 
 describe("build script", () => {
-  test("build script runs vite before tsc", async () => {
+  test("build script runs tsc before vite", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "scaffold-test-"));
     const { dir: npmDir } = createNpmStub();
     const originalPath = process.env.PATH;
@@ -33,7 +33,7 @@ describe("build script", () => {
       };
       const { outDir } = await scaffoldProject(answers);
       const pkg = JSON.parse(readFileSync(join(outDir, "package.json"), "utf8"));
-      assert.equal(pkg.scripts.build, "vite build && tsc");
+      assert.equal(pkg.scripts.build, "tsc && vite build");
     } finally {
       process.chdir(cwd);
       process.env.PATH = originalPath;

--- a/test/dev-script.test.js
+++ b/test/dev-script.test.js
@@ -14,7 +14,7 @@ function createNpmStub() {
 }
 
 describe("dev script", () => {
-  test("adds tsc watch and dev deps", async () => {
+  test("adds dev script and dev deps", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "scaffold-test-"));
     const { dir: npmDir } = createNpmStub();
     const originalPath = process.env.PATH;
@@ -33,14 +33,8 @@ describe("dev script", () => {
       };
       const { outDir } = await scaffoldProject(answers);
       const pkg = JSON.parse(readFileSync(join(outDir, "package.json"), "utf8"));
-      assert.equal(
-        pkg.scripts.dev,
-        "cross-env NODE_ENV=development concurrently \"tsc -w\" \"vite --config vite.config.js\" \"electron .\""
-      );
+      assert.equal(pkg.scripts.dev, "vite --config vite.config.ts");
       assert.ok(pkg.devDependencies.typescript);
-      assert.ok(pkg.devDependencies["@types/node"]);
-      assert.ok(pkg.devDependencies["cross-env"], "cross-env missing");
-      assert.ok(pkg.devDependencies.concurrently, "concurrently missing");
     } finally {
       process.chdir(cwd);
       process.env.PATH = originalPath;

--- a/test/start-script.test.js
+++ b/test/start-script.test.js
@@ -14,7 +14,7 @@ function createNpmStub() {
 }
 
 describe("start script", () => {
-  test("adds start script to package.json", async () => {
+  test("adds production start script", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "scaffold-test-"));
     const { dir: npmDir } = createNpmStub();
     const originalPath = process.env.PATH;
@@ -28,12 +28,12 @@ describe("start script", () => {
         description: "",
         author: "",
         license: "MIT",
-        scripts: ["start"],
+        scripts: ["start-build"],
         features: [],
       };
       const { outDir } = await scaffoldProject(answers);
       const pkg = JSON.parse(readFileSync(join(outDir, "package.json"), "utf8"));
-      assert.equal(pkg.scripts.start, "node dist/main.js");
+      assert.equal(pkg.scripts["start-build"], "node dist/main.js");
     } finally {
       process.chdir(cwd);
       process.env.PATH = originalPath;


### PR DESCRIPTION
## Summary
- compile Electron main process to ES modules and load via `electron-main.mjs`
- update TypeScript settings for bundler-style ESM output
- adjust scaffolding scripts and dependencies for pure ESM workflow
- update tests for new commands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864576ed6d4832f81c2b2912dad4340